### PR TITLE
sync_pull_request

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -38,7 +38,8 @@ import static io.netty.util.internal.StringUtil.unescapeCsvFields;
  */
 public class CombinedHttpHeaders extends DefaultHttpHeaders {
     public CombinedHttpHeaders(boolean validate) {
-        super(new CombinedHttpHeadersImpl(CASE_INSENSITIVE_HASHER, valueConverter(validate), nameValidator(validate)));
+        super(new CombinedHttpHeadersImpl(CASE_INSENSITIVE_HASHER, valueConverter(), nameValidator(validate),
+                valueValidator(validate)));
     }
 
     @Override
@@ -87,9 +88,10 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
         }
 
         CombinedHttpHeadersImpl(HashingStrategy<CharSequence> nameHashingStrategy,
-                ValueConverter<CharSequence> valueConverter,
-                DefaultHeaders.NameValidator<CharSequence> nameValidator) {
-            super(nameHashingStrategy, valueConverter, nameValidator);
+                                ValueConverter<CharSequence> valueConverter,
+                                NameValidator<CharSequence> nameValidator,
+                                ValueValidator<CharSequence> valueValidator) {
+            super(nameHashingStrategy, valueConverter, nameValidator, 16, valueValidator);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValidationUtil.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.AsciiString;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
+
+/**
+ * Functions used to perform various validations of HTTP header names and values.
+ */
+@UnstableApi
+public final class HttpHeaderValidationUtil {
+    private HttpHeaderValidationUtil() {
+    }
+
+    /**
+     * Check if a header name is "connection related".
+     * <p>
+     * The <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1">RFC9110</a> only specify an incomplete
+     * list of the following headers:
+     *
+     * <ul>
+     *     <li><tt>Connection</tt></li>
+     *     <li><tt>Proxy-Connection</tt></li>
+     *     <li><tt>Keep-Alive</tt></li>
+     *     <li><tt>TE</tt></li>
+     *     <li><tt>Transfer-Encoding</tt></li>
+     *     <li><tt>Upgrade</tt></li>
+     * </ul>
+     *
+     * @param name the name of the header to check. The check is case-insensitive.
+     * @param ignoreTeHeader {@code true} if the <tt>TE</tt> header should be ignored by this check.
+     * This is relevant for HTTP/2 header validation, where the <tt>TE</tt> header has special rules.
+     * @return {@code true} if the given header name is one of the specified connection-related headers.
+     */
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static boolean isConnectionHeader(CharSequence name, boolean ignoreTeHeader) {
+        // These are the known standard and non-standard connection related headers:
+        // - upgrade (7 chars)
+        // - connection (10 chars)
+        // - keep-alive (10 chars)
+        // - proxy-connection (16 chars)
+        // - transfer-encoding (17 chars)
+        //
+        // See https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2
+        // and https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+        // for the list of connection related headers.
+        //
+        // We scan for these based on the length, then double-check any matching name.
+        int len = name.length();
+        switch (len) {
+            case 2: return ignoreTeHeader? false : contentEqualsIgnoreCase(name, HttpHeaderNames.TE);
+            case 7: return contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE);
+            case 10: return contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
+                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE);
+            case 16: return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
+            case 17: return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * If the given header is {@link HttpHeaderNames#TE} and the given header value is <em>not</em>
+     * {@link HttpHeaderValues#TRAILERS}, then return {@code true}. Otherwie, {@code false}.
+     * <p>
+     * The string comparisons are case-insensitive.
+     * <p>
+     * This check is important for HTTP/2 header validation.
+     *
+     * @param name the header name to check if it is <tt>TE</tt> or not.
+     * @param value the header value to check if it is something other than <tt>TRAILERS</tt>.
+     * @return {@code true} only if the header name is <tt>TE</tt>, and the header value is <em>not</em>
+     * <tt>TRAILERS</tt>. Otherwise, {@code false}.
+     */
+    public static boolean isTeNotTrailers(CharSequence name, CharSequence value) {
+        if (name.length() == 2) {
+            return contentEqualsIgnoreCase(name, HttpHeaderNames.TE) &&
+                    !contentEqualsIgnoreCase(value, HttpHeaderValues.TRAILERS);
+        }
+        return false;
+    }
+
+    /**
+     * Validate the given HTTP header value by searching for any illegal characters.
+     *
+     * @param value the HTTP header value to validate.
+     * @return the index of the first illegal character found, or {@code -1} if there are none and the header value is
+     * valid.
+     */
+    public static int validateValidHeaderValue(CharSequence value) {
+        int length = value.length();
+        if (length == 0) {
+            return -1;
+        }
+        if (value instanceof AsciiString) {
+            return verifyValidHeaderValueAsciiString((AsciiString) value);
+        }
+        return verifyValidHeaderValueCharSequence(value);
+    }
+
+    private static int verifyValidHeaderValueAsciiString(AsciiString value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        final byte[] array = value.array();
+        final int start = value.arrayOffset();
+        int b = array[start] & 0xFF;
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = start + 1; i < length; i++) {
+            b = array[i] & 0xFF;
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i - start;
+            }
+        }
+        return -1;
+    }
+
+    private static int verifyValidHeaderValueCharSequence(CharSequence value) {
+        // Validate value to field-content rule.
+        //  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+        //  field-vchar    = VCHAR / obs-text
+        //  VCHAR          = %x21-7E ; visible (printing) characters
+        //  obs-text       = %x80-FF
+        //  SP             = %x20
+        //  HTAB           = %x09 ; horizontal tab
+        //  See: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        //  And: https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1
+        int b = value.charAt(0);
+        if (b < 0x21 || b == 0x7F) {
+            return 0;
+        }
+        int length = value.length();
+        for (int i = 1; i < length; i++) {
+            b = value.charAt(i);
+            if (b < 0x20 && b != 0x09 || b == 0x7F) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate a <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> contains only allowed
+     * characters.
+     * <p>
+     * The <a href="https://tools.ietf.org/html/rfc2616#section-2.2">token</a> format is used for variety of HTTP
+     * components, like  <a href="https://tools.ietf.org/html/rfc6265#section-4.1.1">cookie-name</a>,
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">field-name</a> of a
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2">header-field</a>, or
+     * <a href="https://tools.ietf.org/html/rfc7231#section-4">request method</a>.
+     *
+     * @param token the token to validate.
+     * @return the index of the first invalid token character found, or {@code -1} if there are none.
+     */
+    public static int validateToken(CharSequence token) {
+        if (token instanceof AsciiString) {
+            return validateAsciiStringToken((AsciiString) token);
+        }
+        return validateCharSequenceToken(token);
+    }
+
+    /**
+     * Validate that an {@link AsciiString} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the ascii string to validate.
+     */
+    private static int validateAsciiStringToken(AsciiString token) {
+        byte[] array = token.array();
+        for (int i = token.arrayOffset(), len = token.arrayOffset() + token.length(); i < len; i++) {
+            if (!BitSet128.contains(array[i], TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i - token.arrayOffset();
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Validate that a {@link CharSequence} contain onlu valid
+     * <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">token</a> characters.
+     *
+     * @param token the character sequence to validate.
+     */
+    private static int validateCharSequenceToken(CharSequence token) {
+        for (int i = 0, len = token.length(); i < len; i++) {
+            byte value = (byte) token.charAt(i);
+            if (!BitSet128.contains(value, TOKEN_CHARS_HIGH, TOKEN_CHARS_LOW)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static final long TOKEN_CHARS_HIGH;
+    private static final long TOKEN_CHARS_LOW;
+    static {
+        // HEADER
+        // header-field   = field-name ":" OWS field-value OWS
+        //
+        // field-name     = token
+        // token          = 1*tchar
+        //
+        // tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+        //                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        //                    / DIGIT / ALPHA
+        //                    ; any VCHAR, except delimiters.
+        //  Delimiters are chosen
+        //   from the set of US-ASCII visual characters not allowed in a token
+        //   (DQUOTE and "(),/:;<=>?@[\]{}")
+        //
+        // COOKIE
+        // cookie-pair       = cookie-name "=" cookie-value
+        // cookie-name       = token
+        // token          = 1*<any CHAR except CTLs or separators>
+        // CTL = <any US-ASCII control character
+        //       (octets 0 - 31) and DEL (127)>
+        // separators     = "(" | ")" | "<" | ">" | "@"
+        //                      | "," | ";" | ":" | "\" | <">
+        //                      | "/" | "[" | "]" | "?" | "="
+        //                      | "{" | "}" | SP | HT
+        //
+        // field-name's token is equivalent to cookie-name's token, we can reuse the tchar mask for both:
+        BitSet128 tokenChars = new BitSet128()
+                .range('0', '9').range('a', 'z').range('A', 'Z') // Alphanumeric.
+                .bits('-', '.', '_', '~') // Unreserved characters.
+                .bits('!', '#', '$', '%', '&', '\'', '*', '+', '^', '`', '|'); // Token special characters.
+        TOKEN_CHARS_HIGH = tokenChars.high();
+        TOKEN_CHARS_LOW = tokenChars.low();
+    }
+
+    private static final class BitSet128 {
+        private long high;
+        private long low;
+
+        BitSet128 range(char fromInc, char toInc) {
+            for (int bit = fromInc; bit <= toInc; bit++) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        BitSet128 bits(char... bits) {
+            for (char bit : bits) {
+                if (bit < 64) {
+                    low |= 1L << bit;
+                } else {
+                    high |= 1L << bit - 64;
+                }
+            }
+            return this;
+        }
+
+        long high() {
+            return high;
+        }
+
+        long low() {
+            return low;
+        }
+
+        static boolean contains(byte bit, long high, long low) {
+            if (bit < 0) {
+                return false;
+            }
+            if (bit < 64) {
+                return 0 != (low & 1L << bit);
+            }
+            return 0 != (high & 1L << bit - 64);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageUtil.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.handler.codec.http;
 
 import io.netty.util.internal.StringUtil;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.handler.codec.http.HttpHeadersTestUtils.HeaderValue;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -80,11 +81,11 @@ public class DefaultHttpHeadersTest {
     @Test
     public void keysShouldBeCaseInsensitiveInHeadersEquals() {
         DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
-        headers1.add(of("name1"), Arrays.asList("value1", "value2", "value3"));
+        headers1.add(of("name1"), asList("value1", "value2", "value3"));
         headers1.add(of("nAmE2"), of("value4"));
 
         DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
-        headers2.add(of("naMe1"), Arrays.asList("value1", "value2", "value3"));
+        headers2.add(of("naMe1"), asList("value1", "value2", "value3"));
         headers2.add(of("NAME2"), of("value4"));
 
         assertEquals(headers1, headers1);
@@ -259,7 +260,7 @@ public class DefaultHttpHeadersTest {
                 .add(HttpHeaderNames.CONTENT_LENGTH, 10)
                 .names();
 
-        String[] namesArray = nettyHeaders.toArray(new String[0]);
+        String[] namesArray = nettyHeaders.toArray(EmptyArrays.EMPTY_STRINGS);
         assertArrayEquals(namesArray, new String[] { HttpHeaderNames.CONTENT_LENGTH.toString() });
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
@@ -1,0 +1,585 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.AsciiString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static io.netty.handler.codec.http.HttpHeaderValidationUtil.validateToken;
+import static io.netty.handler.codec.http.HttpHeaderValidationUtil.validateValidHeaderValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Execution(ExecutionMode.CONCURRENT) // We have a couple of fairly slow tests here. Better to run them in parallel.
+public class HttpHeaderValidationUtilTest {
+    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
+    public static List<Arguments> connectionRelatedHeaders() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(header(false, HttpHeaderNames.ACCEPT));
+        list.add(header(false, HttpHeaderNames.ACCEPT_CHARSET));
+        list.add(header(false, HttpHeaderNames.ACCEPT_ENCODING));
+        list.add(header(false, HttpHeaderNames.ACCEPT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.ACCEPT_RANGES));
+        list.add(header(false, HttpHeaderNames.ACCEPT_PATCH));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_MAX_AGE));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD));
+        list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK));
+        list.add(header(false, HttpHeaderNames.AGE));
+        list.add(header(false, HttpHeaderNames.ALLOW));
+        list.add(header(false, HttpHeaderNames.AUTHORIZATION));
+        list.add(header(false, HttpHeaderNames.CACHE_CONTROL));
+        list.add(header(true, HttpHeaderNames.CONNECTION));
+        list.add(header(false, HttpHeaderNames.CONTENT_BASE));
+        list.add(header(false, HttpHeaderNames.CONTENT_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_LANGUAGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_LENGTH));
+        list.add(header(false, HttpHeaderNames.CONTENT_LOCATION));
+        list.add(header(false, HttpHeaderNames.CONTENT_TRANSFER_ENCODING));
+        list.add(header(false, HttpHeaderNames.CONTENT_DISPOSITION));
+        list.add(header(false, HttpHeaderNames.CONTENT_MD5));
+        list.add(header(false, HttpHeaderNames.CONTENT_RANGE));
+        list.add(header(false, HttpHeaderNames.CONTENT_SECURITY_POLICY));
+        list.add(header(false, HttpHeaderNames.CONTENT_TYPE));
+        list.add(header(false, HttpHeaderNames.COOKIE));
+        list.add(header(false, HttpHeaderNames.DATE));
+        list.add(header(false, HttpHeaderNames.DNT));
+        list.add(header(false, HttpHeaderNames.ETAG));
+        list.add(header(false, HttpHeaderNames.EXPECT));
+        list.add(header(false, HttpHeaderNames.EXPIRES));
+        list.add(header(false, HttpHeaderNames.FROM));
+        list.add(header(false, HttpHeaderNames.HOST));
+        list.add(header(false, HttpHeaderNames.IF_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_MODIFIED_SINCE));
+        list.add(header(false, HttpHeaderNames.IF_NONE_MATCH));
+        list.add(header(false, HttpHeaderNames.IF_RANGE));
+        list.add(header(false, HttpHeaderNames.IF_UNMODIFIED_SINCE));
+        list.add(header(true, HttpHeaderNames.KEEP_ALIVE));
+        list.add(header(false, HttpHeaderNames.LAST_MODIFIED));
+        list.add(header(false, HttpHeaderNames.LOCATION));
+        list.add(header(false, HttpHeaderNames.MAX_FORWARDS));
+        list.add(header(false, HttpHeaderNames.ORIGIN));
+        list.add(header(false, HttpHeaderNames.PRAGMA));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.PROXY_AUTHORIZATION));
+        list.add(header(true, HttpHeaderNames.PROXY_CONNECTION));
+        list.add(header(false, HttpHeaderNames.RANGE));
+        list.add(header(false, HttpHeaderNames.REFERER));
+        list.add(header(false, HttpHeaderNames.RETRY_AFTER));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY1));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY2));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_LOCATION));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ORIGIN));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_VERSION));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_KEY));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_ACCEPT));
+        list.add(header(false, HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
+        list.add(header(false, HttpHeaderNames.SERVER));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE));
+        list.add(header(false, HttpHeaderNames.SET_COOKIE2));
+        list.add(header(true, HttpHeaderNames.TE));
+        list.add(header(false, HttpHeaderNames.TRAILER));
+        list.add(header(true, HttpHeaderNames.TRANSFER_ENCODING));
+        list.add(header(true, HttpHeaderNames.UPGRADE));
+        list.add(header(false, HttpHeaderNames.UPGRADE_INSECURE_REQUESTS));
+        list.add(header(false, HttpHeaderNames.USER_AGENT));
+        list.add(header(false, HttpHeaderNames.VARY));
+        list.add(header(false, HttpHeaderNames.VIA));
+        list.add(header(false, HttpHeaderNames.WARNING));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_LOCATION));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_ORIGIN));
+        list.add(header(false, HttpHeaderNames.WEBSOCKET_PROTOCOL));
+        list.add(header(false, HttpHeaderNames.WWW_AUTHENTICATE));
+        list.add(header(false, HttpHeaderNames.X_FRAME_OPTIONS));
+        list.add(header(false, HttpHeaderNames.X_REQUESTED_WITH));
+
+        return list;
+    }
+
+    private static Arguments header(final boolean isConnectionRelated, final AsciiString headerName) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, isConnectionRelated};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersAsciiString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("connectionRelatedHeaders")
+    void mustIdentifyConnectionRelatedHeadersString(AsciiString headerName, boolean isConnectionRelated) {
+        assertEquals(isConnectionRelated, HttpHeaderValidationUtil.isConnectionHeader(headerName.toString(), false));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredAsciiString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE, true));
+    }
+
+    @Test
+    void teHeaderIsNotConnectionRelatedWhenIgnoredString() {
+        assertFalse(HttpHeaderValidationUtil.isConnectionHeader(HttpHeaderNames.TE.toString(), true));
+    }
+
+    public static List<Arguments> teIsTrailersTruthTable() {
+        List<Arguments> list = new ArrayList<Arguments>();
+
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TE, HttpHeaderValues.CHUNKED, true));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.CHUNKED, false));
+        list.add(teIsTrailter(HttpHeaderNames.COOKIE, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.TRAILERS, false));
+        list.add(teIsTrailter(HttpHeaderNames.TRAILER, HttpHeaderValues.CHUNKED, false));
+
+        return list;
+    }
+
+    private static Arguments teIsTrailter(
+            final AsciiString headerName, final AsciiString headerValue, final boolean result) {
+        return new Arguments() {
+            @Override
+            public Object[] get() {
+                return new Object[]{headerName, headerValue, result};
+            }
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotWithNameAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNameAsciiStringAndValueString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName, headerValue.toString()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("teIsTrailersTruthTable")
+    void whenTeIsNotTrailerOrNotSWithNametringAndValueAsciiString(
+            AsciiString headerName, AsciiString headerValue, boolean result) {
+        assertEquals(result, HttpHeaderValidationUtil.isTeNotTrailers(headerName.toString(), headerValue));
+    }
+
+    public static List<AsciiString> illegalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            list.add(new AsciiString(new byte[]{i, 'a'}));
+        }
+        list.add(new AsciiString(new byte[]{0x7F, 'a'}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(0, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0x21; i <= 0xFF; i++) {
+            if (i == 0x7F) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[]{(byte) i, 'a'}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalFirstChar")
+    void allOtherCharsAreLegalFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    public static List<AsciiString> illegalNotFirstChar() {
+        ArrayList<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (byte i = 0; i < 0x21; i++) {
+            if (i == ' ' || i == '\t') {
+                continue; // Space and horizontal tab are only illegal as first chars.
+            }
+            list.add(new AsciiString(new byte[]{'a', i}));
+        }
+        list.add(new AsciiString(new byte[]{'a', 0x7F}));
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalAsciiString(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValuesMustFailIfNotFirstCharIsIllegalCharSequence(AsciiString value) {
+        assertEquals(1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    public static List<AsciiString> legalNotFirstChar() {
+        List<AsciiString> list = new ArrayList<AsciiString>();
+
+        for (int i = 0; i < 0xFF; i++) {
+            if (i == 0x7F || i < 0x21 && (i != ' ' || i != '\t')) {
+                continue;
+            }
+            list.add(new AsciiString(new byte[] {'a', (byte) i}));
+        }
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsAsciiString(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(value));
+    }
+
+    @ParameterizedTest
+    @MethodSource("legalNotFirstChar")
+    void allOtherCharsArgLegalNotFirstCharsCharSequence(AsciiString value) {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(value)));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsAsciiString() {
+        assertEquals(-1, validateValidHeaderValue(AsciiString.EMPTY_STRING));
+    }
+
+    @Test
+    void emptyValuesHaveNoIllegalCharsCharSequence() {
+        assertEquals(-1, validateValidHeaderValue(asCharSequence(AsciiString.EMPTY_STRING)));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesAsciiString() {
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\n")));
+        assertEquals(1, validateValidHeaderValue(AsciiString.of("a\r")));
+    }
+
+    @Test
+    void headerValuesCannotEndWithNewlinesCharSequence() {
+        assertEquals(1, validateValidHeaderValue("a\n"));
+        assertEquals(1, validateValidHeaderValue("a\r"));
+    }
+
+    /**
+     * This method returns a {@link CharSequence} instance that has the same contents as the given {@link AsciiString},
+     * but which is, critically, <em>not</em> itself an {@link AsciiString}.
+     * <p>
+     * Some methods specialise on {@link AsciiString}, while having a {@link CharSequence} based fallback.
+     * <p>
+     * This method exist to test those fallback methods.
+     *
+     * @param value The {@link AsciiString} instance to wrap.
+     * @return A new {@link CharSequence} instance which backed by the given {@link AsciiString},
+     * but which is itself not an {@link AsciiString}.
+     */
+    private static CharSequence asCharSequence(final AsciiString value) {
+        return new CharSequence() {
+            @Override
+            public int length() {
+                return value.length();
+            }
+
+            @Override
+            public char charAt(int index) {
+                return value.charAt(index);
+            }
+
+            @Override
+            public CharSequence subSequence(int start, int end) {
+                return asCharSequence(value.subSequence(start, end));
+            }
+        };
+    }
+
+    private static final IllegalArgumentException VALIDATION_EXCEPTION = new IllegalArgumentException() {
+        private static final long serialVersionUID = -8857428534361331089L;
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+    };
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerValueValidationMustRejectAllValuesRejectedByOldAlgorithm() {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderValueValidationAlgorithm(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateValidHeaderValue(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateValidHeaderValue(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderValueValidationAlgorithm(CharSequence seq) {
+        int state = 0;
+        // Start looping through each of the character
+        for (int index = 0; index < seq.length(); index++) {
+            state = oldValidationAlgorithmValidateValueChar(state, seq.charAt(index));
+        }
+
+        if (state != 0) {
+            throw VALIDATION_EXCEPTION;
+        }
+    }
+
+    private static int oldValidationAlgorithmValidateValueChar(int state, char character) {
+        /*
+         * State:
+         * 0: Previous character was neither CR nor LF
+         * 1: The previous character was CR
+         * 2: The previous character was LF
+         */
+        if ((character & ~15) == 0) {
+            // Check the absolutely prohibited characters.
+            switch (character) {
+                case 0x0: // NULL
+                    throw VALIDATION_EXCEPTION;
+                case 0x0b: // Vertical tab
+                    throw VALIDATION_EXCEPTION;
+                case '\f':
+                    throw VALIDATION_EXCEPTION;
+                default:
+                    break;
+            }
+        }
+
+        // Check the CRLF (HT | SP) pattern
+        switch (state) {
+            case 0:
+                switch (character) {
+                    case '\r':
+                        return 1;
+                    case '\n':
+                        return 2;
+                    default:
+                        break;
+                }
+                break;
+            case 1:
+                if (character == '\n') {
+                    return 2;
+                }
+                throw VALIDATION_EXCEPTION;
+            case 2:
+                switch (character) {
+                    case '\t':
+                    case ' ':
+                        return 0;
+                    default:
+                        throw VALIDATION_EXCEPTION;
+                }
+            default:
+                break;
+        }
+        return state;
+    }
+
+    @DisabledForJreRange(max = JRE.JAVA_17) // This test is much too slow on older Java versions.
+    @Test
+    void headerNameValidationMustRejectAllNamesRejectedByOldAlgorithm() throws Exception {
+        byte[] array = new byte[4];
+        final ByteBuffer buffer = ByteBuffer.wrap(array);
+        final AsciiString asciiString = new AsciiString(buffer, false);
+        CharSequence charSequence = asCharSequence(asciiString);
+        int i = Integer.MIN_VALUE;
+        Supplier<String> failureMessageSupplier = new Supplier<String>() {
+            @Override
+            public String get() {
+                return "validation mismatch on string '" + asciiString + "', iteration " + buffer.getInt(0);
+            }
+        };
+
+        do {
+            buffer.putInt(0, i);
+            try {
+                oldHeaderNameValidationAlgorithmAsciiString(asciiString);
+            } catch (IllegalArgumentException ignore) {
+                assertNotEquals(-1, validateToken(asciiString), failureMessageSupplier);
+                assertNotEquals(-1, validateToken(charSequence), failureMessageSupplier);
+            }
+            i++;
+        } while (i != Integer.MIN_VALUE);
+    }
+
+    private static void oldHeaderNameValidationAlgorithmAsciiString(AsciiString name) throws Exception {
+        byte[] array = name.array();
+        for (int i = name.arrayOffset(), len = name.arrayOffset() + name.length(); i < len; i++) {
+            validateHeaderNameElement(array[i]);
+        }
+    }
+
+    private static void validateHeaderNameElement(byte value) {
+        switch (value) {
+            case 0x1c:
+            case 0x1d:
+            case 0x1e:
+            case 0x1f:
+            case 0x00:
+            case '\t':
+            case '\n':
+            case 0x0b:
+            case '\f':
+            case '\r':
+            case ' ':
+            case ',':
+            case ':':
+            case ';':
+            case '=':
+                throw VALIDATION_EXCEPTION;
+            default:
+                // Check to see if the character is not an ASCII character, or invalid
+                if (value < 0) {
+                    throw VALIDATION_EXCEPTION;
+                }
+        }
+    }
+
+    public static List<Character> validTokenChars() {
+        List<Character> list = new ArrayList<Character>();
+        for (char c = '0'; c <= '9'; c++) {
+            list.add(c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            list.add(c);
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            list.add(c);
+        }
+
+        // Unreserved characters:
+        list.add('-');
+        list.add('.');
+        list.add('_');
+        list.add('~');
+
+        // Token special characters:
+        list.add('!');
+        list.add('#');
+        list.add('$');
+        list.add('%');
+        list.add('&');
+        list.add('\'');
+        list.add('*');
+        list.add('+');
+        list.add('^');
+        list.add('`');
+        list.add('|');
+
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidFirstCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {(byte) tokenChar, 'a'});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = tokenChar + "a";
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validTokenChars")
+    void allTokenCharsAreValidSecondCharHeaderName(char tokenChar) {
+        AsciiString asciiString = new AsciiString(new byte[] {'a', (byte) tokenChar});
+        CharSequence charSequence = asCharSequence(asciiString);
+        String string = "a" + tokenChar;
+
+        assertEquals(-1, validateToken(asciiString));
+        assertEquals(-1, validateToken(charSequence));
+        assertEquals(-1, validateToken(string));
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.CharSequenceValueConverter;
 import io.netty.handler.codec.DefaultHeaders;
+import io.netty.handler.codec.http.HttpHeaderValidationUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.PlatformDependent;
@@ -23,6 +24,7 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
@@ -44,6 +46,7 @@ public class DefaultHttp2Headers
                 PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                         "empty headers are not allowed [%s]", name));
             }
+
             if (name instanceof AsciiString) {
                 final int index;
                 try {
@@ -68,6 +71,28 @@ public class DefaultHttp2Headers
                                 "invalid header name [%s]", name));
                     }
                 }
+            }
+
+            if (hasPseudoHeaderFormat(name)) {
+                final Http2Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
+                if (pseudoHeader == null) {
+                    PlatformDependent.throwException(connectionError(
+                            PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name));
+                }
+            } else if (HttpHeaderValidationUtil.isConnectionHeader(name, true)) {
+                PlatformDependent.throwException(connectionError(
+                        PROTOCOL_ERROR, "Illegal connection-specific header '%s' encountered.", name));
+            }
+        }
+    };
+
+    private static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
+        @Override
+        public void validate(CharSequence value) {
+            int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
+            if (index != -1) {
+                throw new IllegalArgumentException("a header value contains prohibited character 0x" +
+                        Integer.toHexString(value.charAt(index)) + " at index " + index + '.');
             }
         }
     };
@@ -104,6 +129,7 @@ public class DefaultHttp2Headers
      * <a href="https://tools.ietf.org/html/rfc7540">rfc7540</a>. {@code false} to not validate header names.
      * @param arraySizeHint A hint as to how large the hash data structure should be.
      * The next positive power of two will be used. An upper bound may be enforced.
+     * @see DefaultHttp2Headers#DefaultHttp2Headers(boolean, boolean, int)
      */
     @SuppressWarnings("unchecked")
     public DefaultHttp2Headers(boolean validate, int arraySizeHint) {
@@ -113,6 +139,50 @@ public class DefaultHttp2Headers
               CharSequenceValueConverter.INSTANCE,
               validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
               arraySizeHint);
+    }
+
+    /**
+     * Create a new instance.
+     * @param validate {@code true} to validate header names according to
+     * <a href="https://tools.ietf.org/html/rfc7540">rfc7540</a>. {@code false} to not validate header names.
+     * @param validateValues {@code true} to validate header values according to
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.2">rfc7230</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1">rfc5234</a>. Otherwise, {@code false}
+     * (the default) to not validate values.
+     * @param arraySizeHint A hint as to how large the hash data structure should be.
+     * The next positive power of two will be used. An upper bound may be enforced.
+     */
+    @SuppressWarnings("unchecked")
+    public DefaultHttp2Headers(boolean validate, boolean validateValues, int arraySizeHint) {
+        // Case sensitive compare is used because it is cheaper, and header validation can be used to catch invalid
+        // headers.
+        super(CASE_SENSITIVE_HASHER,
+                CharSequenceValueConverter.INSTANCE,
+                validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+                arraySizeHint,
+                validateValues ? VALUE_VALIDATOR : (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
+    }
+
+    @Override
+    protected void validateName(NameValidator<CharSequence> validator, boolean forAdd, CharSequence name) {
+        super.validateName(validator, forAdd, name);
+        if (nameValidator() == HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
+            if (contains(name)) {
+                PlatformDependent.throwException(connectionError(
+                        PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name));
+            }
+        }
+    }
+
+    @Override
+    protected void validateValue(ValueValidator<CharSequence> validator, CharSequence name, CharSequence value) {
+        if (nameValidator() == HTTP2_NAME_VALIDATOR) {
+            if (HttpHeaderValidationUtil.isTeNotTrailers(name, value)) {
+                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                        "Illegal value specified for the 'TE' header (only 'trailers' is allowed)."));
+            }
+        }
+        super.validateValue(validator, name, value);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -31,6 +31,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
 
     private final HpackDecoder hpackDecoder;
     private final boolean validateHeaders;
+    private final boolean validateHeaderValues;
     private long maxHeaderListSizeGoAway;
 
     /**
@@ -43,8 +44,24 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
         this(true);
     }
 
+    /**
+     * Create a new instance.
+     * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     */
     public DefaultHttp2HeadersDecoder(boolean validateHeaders) {
         this(validateHeaders, DEFAULT_HEADER_LIST_SIZE);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     * This validates everything except header values.
+     * @param validateHeaderValues {@code true} to validate that header <em>values</em> are valid according to the RFC.
+     * Since this is potentially expensive, it can be enabled separately from {@code validateHeaders}.
+     */
+    public DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues) {
+        this(validateHeaders, validateHeaderValues, DEFAULT_HEADER_LIST_SIZE);
     }
 
     /**
@@ -56,12 +73,28 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
      *  (which is dangerous).
      */
     public DefaultHttp2HeadersDecoder(boolean validateHeaders, long maxHeaderListSize) {
-        this(validateHeaders, maxHeaderListSize, /* initialHuffmanDecodeCapacity= */ -1);
+        this(validateHeaders, false, new HpackDecoder(maxHeaderListSize));
     }
 
     /**
      * Create a new instance.
      * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     * This validates everything except header values.
+     * @param validateHeaderValues {@code true} to validate that header <em>values</em> are valid according to the RFC.
+     * Since this is potentially expensive, it can be enabled separately from {@code validateHeaders}.
+     * @param maxHeaderListSize This is the only setting that can be configured before notifying the peer.
+     *  This is because <a href="https://tools.ietf.org/html/rfc7540#section-6.5.1">SETTINGS_MAX_HEADER_LIST_SIZE</a>
+     *  allows a lower than advertised limit from being enforced, and the default limit is unlimited
+     *  (which is dangerous).
+     */
+    public DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues, long maxHeaderListSize) {
+        this(validateHeaders, validateHeaderValues, new HpackDecoder(maxHeaderListSize));
+    }
+
+    /**
+     * Create a new instance.
+     * @param validateHeaders {@code true} to validate headers are valid according to the RFC.
+     * This validates everything except header values.
      * @param maxHeaderListSize This is the only setting that can be configured before notifying the peer.
      *  This is because <a href="https://tools.ietf.org/html/rfc7540#section-6.5.1">SETTINGS_MAX_HEADER_LIST_SIZE</a>
      *  allows a lower than advertised limit from being enforced, and the default limit is unlimited
@@ -70,16 +103,17 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
      */
     public DefaultHttp2HeadersDecoder(boolean validateHeaders, long maxHeaderListSize,
                                       @Deprecated int initialHuffmanDecodeCapacity) {
-        this(validateHeaders, new HpackDecoder(maxHeaderListSize));
+        this(validateHeaders, false, new HpackDecoder(maxHeaderListSize));
     }
 
     /**
-     * Exposed Used for testing only! Default values used in the initial settings frame are overridden intentionally
+     * Exposed for testing only! Default values used in the initial settings frame are overridden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
-    DefaultHttp2HeadersDecoder(boolean validateHeaders, HpackDecoder hpackDecoder) {
+    DefaultHttp2HeadersDecoder(boolean validateHeaders, boolean validateHeaderValues, HpackDecoder hpackDecoder) {
         this.hpackDecoder = ObjectUtil.checkNotNull(hpackDecoder, "hpackDecoder");
         this.validateHeaders = validateHeaders;
+        this.validateHeaderValues = validateHeaderValues;
         maxHeaderListSizeGoAway =
                 Http2CodecUtil.calculateMaxHeaderListSizeGoAway(hpackDecoder.getMaxHeaderListSize());
     }
@@ -147,6 +181,10 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
 
     /**
      * Determines if the headers should be validated as a result of the decode operation.
+     * <p>
+     * <strong>Note:</strong> This does not include validation of header <em>values</em>, since that is potentially
+     * expensive to do. Value validation is instead {@linkplain #validateHeaderValues() enabled separately}.
+     *
      * @return {@code true} if the headers should be validated as a result of the decode operation.
      */
     protected final boolean validateHeaders() {
@@ -154,10 +192,22 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     }
 
     /**
+     * Determines if the header values should be validated as a result of the decode operation.
+     * <p>
+     * <strong>Note:</strong> This <em>only</em> validates the values of headers. All other header validations are
+     * instead {@linkplain #validateHeaders() enabled separately}.
+     *
+     * @return {@code true} if the header values should be validated as a result of the decode operation.
+     */
+    protected boolean validateHeaderValues() { // Not 'final' due to backwards compatibility.
+        return validateHeaderValues;
+    }
+
+    /**
      * Create a new {@link Http2Headers} object which will store the results of the decode operation.
      * @return a new {@link Http2Headers} object which will store the results of the decode operation.
      */
     protected Http2Headers newHeaders() {
-        return new DefaultHttp2Headers(validateHeaders, (int) headerArraySizeAccumulator);
+        return new DefaultHttp2Headers(validateHeaders, validateHeaderValues, (int) headerArraySizeAccumulator);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -32,8 +32,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.HpackUtil.IndexType;
 import io.netty.util.AsciiString;
 
@@ -50,7 +48,6 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.getPseudoHeader;
 import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.EMPTY_STRING;
-import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 final class HpackDecoder {
@@ -126,8 +123,9 @@ final class HpackDecoder {
      * <p>
      * This method assumes the entire header block is contained in {@code in}.
      */
-    public void decode(int streamId, ByteBuf in, Http2Headers headers, boolean validateHeaders) throws Http2Exception {
-        Http2HeadersSink sink = new Http2HeadersSink(streamId, headers, maxHeaderListSize, validateHeaders);
+    void decode(int streamId, ByteBuf in, Http2Headers headers, boolean validateHeaders) throws Http2Exception {
+        Http2HeadersSink sink = new Http2HeadersSink(
+                streamId, headers, maxHeaderListSize, validateHeaders);
         decode(in, sink);
 
         // Now that we've read all of our headers we can perform the validation steps. We must
@@ -135,13 +133,13 @@ final class HpackDecoder {
         sink.finish();
     }
 
-    private void decode(ByteBuf in, Sink sink) throws Http2Exception {
+    private void decode(ByteBuf in, Http2HeadersSink sink) throws Http2Exception {
         int index = 0;
         int nameLength = 0;
         int valueLength = 0;
         byte state = READ_HEADER_REPRESENTATION;
         boolean huffmanEncoded = false;
-        CharSequence name = null;
+        AsciiString name = null;
         IndexType indexType = IndexType.NONE;
         while (in.isReadable()) {
             switch (state) {
@@ -162,7 +160,9 @@ final class HpackDecoder {
                                 break;
                             default:
                                 HpackHeaderField indexedHeader = getIndexedHeader(index);
-                                sink.appendToHeaderList(indexedHeader.name, indexedHeader.value);
+                                sink.appendToHeaderList(
+                                        (AsciiString) indexedHeader.name,
+                                        (AsciiString) indexedHeader.value);
                         }
                     } else if ((b & 0x40) == 0x40) {
                         // Literal Header Field with Incremental Indexing
@@ -217,7 +217,9 @@ final class HpackDecoder {
 
                 case READ_INDEXED_HEADER:
                     HpackHeaderField indexedHeader = getIndexedHeader(decodeULE128(in, index));
-                    sink.appendToHeaderList(indexedHeader.name, indexedHeader.value);
+                    sink.appendToHeaderList(
+                            (AsciiString) indexedHeader.name,
+                            (AsciiString) indexedHeader.value);
                     state = READ_HEADER_REPRESENTATION;
                     break;
 
@@ -290,7 +292,7 @@ final class HpackDecoder {
                         throw notEnoughDataException(in);
                     }
 
-                    CharSequence value = readStringLiteral(in, valueLength, huffmanEncoded);
+                    AsciiString value = readStringLiteral(in, valueLength, huffmanEncoded);
                     insertHeader(sink, name, value, indexType);
                     state = READ_HEADER_REPRESENTATION;
                     break;
@@ -309,7 +311,7 @@ final class HpackDecoder {
      * Set the maximum table size. If this is below the maximum size of the dynamic table used by
      * the encoder, the beginning of the next header block MUST signal this change.
      */
-    public void setMaxHeaderTableSize(long maxHeaderTableSize) throws Http2Exception {
+    void setMaxHeaderTableSize(long maxHeaderTableSize) throws Http2Exception {
         if (maxHeaderTableSize < MIN_HEADER_TABLE_SIZE || maxHeaderTableSize > MAX_HEADER_TABLE_SIZE) {
             throw connectionError(PROTOCOL_ERROR, "Header Table Size must be >= %d and <= %d but was %d",
                     MIN_HEADER_TABLE_SIZE, MAX_HEADER_TABLE_SIZE, maxHeaderTableSize);
@@ -323,16 +325,7 @@ final class HpackDecoder {
         }
     }
 
-    /**
-     * @deprecated use {@link #setMaxHeaderListSize(long)}; {@code maxHeaderListSizeGoAway} is
-     *     ignored
-     */
-    @Deprecated
-    public void setMaxHeaderListSize(long maxHeaderListSize, long maxHeaderListSizeGoAway) throws Http2Exception {
-        setMaxHeaderListSize(maxHeaderListSize);
-    }
-
-    public void setMaxHeaderListSize(long maxHeaderListSize) throws Http2Exception {
+    void setMaxHeaderListSize(long maxHeaderListSize) throws Http2Exception {
         if (maxHeaderListSize < MIN_HEADER_LIST_SIZE || maxHeaderListSize > MAX_HEADER_LIST_SIZE) {
             throw connectionError(PROTOCOL_ERROR, "Header List Size must be >= %d and <= %d but was %d",
                     MIN_HEADER_TABLE_SIZE, MAX_HEADER_TABLE_SIZE, maxHeaderListSize);
@@ -340,7 +333,7 @@ final class HpackDecoder {
         this.maxHeaderListSize = maxHeaderListSize;
     }
 
-    public long getMaxHeaderListSize() {
+    long getMaxHeaderListSize() {
         return maxHeaderListSize;
     }
 
@@ -348,7 +341,7 @@ final class HpackDecoder {
      * Return the maximum table size. This is the maximum size allowed by both the encoder and the
      * decoder.
      */
-    public long getMaxHeaderTableSize() {
+    long getMaxHeaderTableSize() {
         return hpackDynamicTable.capacity();
     }
 
@@ -382,76 +375,26 @@ final class HpackDecoder {
         hpackDynamicTable.setCapacity(dynamicTableSize);
     }
 
-    private static HeaderType validate(int streamId, CharSequence name,
-                                       HeaderType previousHeaderType, Http2Headers headers, CharSequence value)
+    private static HeaderType validateHeader(int streamId, AsciiString name, HeaderType previousHeaderType)
             throws Http2Exception {
         if (hasPseudoHeaderFormat(name)) {
             if (previousHeaderType == HeaderType.REGULAR_HEADER) {
                 throw streamError(streamId, PROTOCOL_ERROR,
                         "Pseudo-header field '%s' found after regular header.", name);
             }
-
             final Http2Headers.PseudoHeaderName pseudoHeader = getPseudoHeader(name);
-            if (pseudoHeader == null) {
-                throw streamError(streamId, PROTOCOL_ERROR, "Invalid HTTP/2 pseudo-header '%s' encountered.", name);
-            }
-
             final HeaderType currentHeaderType = pseudoHeader.isRequestOnly() ?
                     HeaderType.REQUEST_PSEUDO_HEADER : HeaderType.RESPONSE_PSEUDO_HEADER;
             if (previousHeaderType != null && currentHeaderType != previousHeaderType) {
                 throw streamError(streamId, PROTOCOL_ERROR, "Mix of request and response pseudo-headers.");
             }
-
-            if (contains(headers, name)) {
-                throw streamError(streamId, PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name);
-            }
-
             return currentHeaderType;
-        }
-        if (isConnectionHeader(name)) {
-            throw streamError(streamId, PROTOCOL_ERROR, "Illegal connection-specific header '%s' encountered.", name);
-        }
-        if (contentEqualsIgnoreCase(name, HttpHeaderNames.TE) &&
-                !contentEqualsIgnoreCase(value, HttpHeaderValues.TRAILERS)) {
-            throw streamError(streamId, PROTOCOL_ERROR,
-                    "Illegal value specified for the 'TE' header (only 'trailers' is allowed).");
         }
 
         return HeaderType.REGULAR_HEADER;
     }
 
-    @SuppressWarnings("deprecation") // We need to check for deprecated headers as well.
-    private static boolean isConnectionHeader(CharSequence name) {
-        // These are the known standard connection related headers:
-        // - upgrade (7 chars)
-        // - connection (10 chars)
-        // - keep-alive (10 chars)
-        // - proxy-connection (16 chars)
-        // - transfer-encoding (17 chars)
-        //
-        // We scan for these based on the length, then double-check any matching name.
-        int len = name.length();
-        if (len < 7 || len > 25) {
-            return false;
-        }
-        if (len <= 10) {
-            if (len == 7 && contentEqualsIgnoreCase(name, HttpHeaderNames.UPGRADE)) {
-                return true;
-            }
-            return len == 10 && (contentEqualsIgnoreCase(name, HttpHeaderNames.CONNECTION) ||
-                    contentEqualsIgnoreCase(name, HttpHeaderNames.KEEP_ALIVE));
-        }
-        if (len == 17) {
-            // Transfer-Encoding is more common, so check it first.
-            return contentEqualsIgnoreCase(name, HttpHeaderNames.TRANSFER_ENCODING);
-        }
-        if (len == 16) {
-            return contentEqualsIgnoreCase(name, HttpHeaderNames.PROXY_CONNECTION);
-        }
-        return false;
-    }
-
-    private static boolean contains(Http2Headers headers, CharSequence name) {
+    private static boolean contains(Http2Headers headers, AsciiString name) {
         if (headers == EmptyHttp2Headers.INSTANCE) {
             return false;
         }
@@ -479,14 +422,20 @@ final class HpackDecoder {
         return false;
     }
 
-    private CharSequence readName(int index) throws Http2Exception {
+    private static Http2Exception illegalHeaderValue(int streamId, AsciiString name, int illegalByte, int index) {
+        return streamError(streamId, PROTOCOL_ERROR,
+                "Illegal header value given for header '%s': illegal byte 0x%X at index %s.",
+                name, illegalByte, index);
+    }
+
+    private AsciiString readName(int index) throws Http2Exception {
         if (index <= HpackStaticTable.length) {
             HpackHeaderField hpackHeaderField = HpackStaticTable.getEntry(index);
-            return hpackHeaderField.name;
+            return (AsciiString) hpackHeaderField.name;
         }
         if (index - HpackStaticTable.length <= hpackDynamicTable.length()) {
             HpackHeaderField hpackHeaderField = hpackDynamicTable.getEntry(index - HpackStaticTable.length);
-            return hpackHeaderField.name;
+            return (AsciiString) hpackHeaderField.name;
         }
         throw READ_NAME_ILLEGAL_INDEX_VALUE;
     }
@@ -501,7 +450,7 @@ final class HpackDecoder {
         throw INDEX_HEADER_ILLEGAL_INDEX_VALUE;
     }
 
-    private void insertHeader(Sink sink, CharSequence name, CharSequence value, IndexType indexType) {
+    private void insertHeader(Http2HeadersSink sink, AsciiString name, AsciiString value, IndexType indexType) {
         sink.appendToHeaderList(name, value);
 
         switch (indexType) {
@@ -518,7 +467,7 @@ final class HpackDecoder {
         }
     }
 
-    private CharSequence readStringLiteral(ByteBuf in, int length, boolean huffmanEncoded) throws Http2Exception {
+    private AsciiString readStringLiteral(ByteBuf in, int length, boolean huffmanEncoded) throws Http2Exception {
         if (huffmanEncoded) {
             return huffmanDecoder.decode(in, length);
         }
@@ -592,30 +541,24 @@ final class HpackDecoder {
         RESPONSE_PSEUDO_HEADER
     }
 
-    private interface Sink {
-        void appendToHeaderList(CharSequence name, CharSequence value);
-        void finish() throws Http2Exception;
-    }
-
-    private static final class Http2HeadersSink implements Sink {
+    private static final class Http2HeadersSink {
         private final Http2Headers headers;
         private final long maxHeaderListSize;
         private final int streamId;
-        private final boolean validate;
+        private final boolean validateHeaders;
         private long headersLength;
         private boolean exceededMaxLength;
         private HeaderType previousType;
         private Http2Exception validationException;
 
-        Http2HeadersSink(int streamId, Http2Headers headers, long maxHeaderListSize, boolean validate) {
+        Http2HeadersSink(int streamId, Http2Headers headers, long maxHeaderListSize, boolean validateHeaders) {
             this.headers = headers;
             this.maxHeaderListSize = maxHeaderListSize;
             this.streamId = streamId;
-            this.validate = validate;
+            this.validateHeaders = validateHeaders;
         }
 
-        @Override
-        public void finish() throws Http2Exception {
+        void finish() throws Http2Exception {
             if (exceededMaxLength) {
                 headerListSizeExceeded(streamId, maxHeaderListSize, true);
             } else if (validationException != null) {
@@ -623,8 +566,7 @@ final class HpackDecoder {
             }
         }
 
-        @Override
-        public void appendToHeaderList(CharSequence name, CharSequence value) {
+        void appendToHeaderList(AsciiString name, AsciiString value) {
             headersLength += HpackHeaderField.sizeOf(name, value);
             exceededMaxLength |= headersLength > maxHeaderListSize;
 
@@ -633,15 +575,17 @@ final class HpackDecoder {
                 return;
             }
 
-            if (validate) {
-                try {
-                    previousType = validate(streamId, name, previousType, headers, value);
-                } catch (Http2Exception ex) {
-                    validationException = ex;
-                    return;
+            try {
+                headers.add(name, value);
+                if (validateHeaders) {
+                    previousType = validateHeader(streamId, name, previousType);
                 }
+            } catch (IllegalArgumentException ex) {
+                validationException = streamError(streamId, PROTOCOL_ERROR, ex,
+                        "Validation failed for header '%s': %s", name, ex.getMessage());
+            } catch (Http2Exception ex) {
+                validationException = streamError(streamId, PROTOCOL_ERROR, ex, ex.getMessage());
             }
-            headers.add(name, value);
         }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -107,7 +107,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     public void encodeHeaders(int streamId, ByteBuf out, Http2Headers headers, SensitivityDetector sensitivityDetector)
@@ -149,7 +149,7 @@ final class HpackEncoder {
 
     /**
      * Encode the header field into the header block.
-     *
+     * <p>
      * <strong>The given {@link CharSequence}s must be immutable!</strong>
      */
     private void encodeHeader(ByteBuf out, CharSequence name, CharSequence value, boolean sensitive, long headerSize) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
@@ -24,6 +23,11 @@ import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_LIST_SIZE;
@@ -138,7 +142,7 @@ public class DefaultHttp2HeadersDecoderTest {
     }
 
     @Test
-    void decodingTrailersTeHeaderMustNotFailValidation() throws Exception {
+    public void decodingTrailersTeHeaderMustNotFailValidation() throws Exception {
         // The TE header is expressly allowed to have the value "trailers".
         ByteBuf buf = null;
         try {
@@ -152,7 +156,7 @@ public class DefaultHttp2HeadersDecoderTest {
 
     @Test
     public void decodingConnectionRelatedHeadersMustFailValidation() throws Exception {
-        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true, true);
         // Standard connection related headers
         verifyValidationFails(decoder, encode(b(":method"), b("GET"), b("keep-alive"), b("timeout=5")));
         verifyValidationFails(decoder, encode(b(":method"), b("GET"),
@@ -170,6 +174,107 @@ public class DefaultHttp2HeadersDecoderTest {
 
         // Only "trailers" is allowed for the TE header:
         verifyValidationFails(decoder, encode(b(":method"), b("GET"), b("te"), b("compress")));
+    }
+
+    public static List<Integer> illegalFirstChar() {
+        ArrayList<Integer> list = new ArrayList<Integer>();
+        for (int i = 0; i < 0x21; i++) {
+            list.add(i);
+        }
+        list.add(0x7F);
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalFirstChar")
+    void decodingInvalidHeaderValueMustFailValidationIfFirstCharIsIllegal(int illegalFirstChar)throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true, true);
+        verifyValidationFails(decoder, encode(b(":method"), b("GET"),
+                b("test_header"), new byte[]{ (byte) illegalFirstChar, (byte) 'a' }));
+    }
+
+    public static List<Integer> illegalNotFirstChar() {
+        ArrayList<Integer> list = new ArrayList<Integer>();
+        for (int i = 0; i < 0x21; i++) {
+            if (i == ' ' || i == '\t') {
+                continue; // Space and horizontal tab are only illegal as first chars.
+            }
+            list.add(i);
+        }
+        list.add(0x7F);
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("illegalNotFirstChar")
+    void decodingInvalidHeaderValueMustFailValidationIfANotFirstCharIsIllegal(int illegalSecondChar) throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true, true);
+        verifyValidationFails(decoder, encode(b(":method"), b("GET"),
+                b("test_header"), new byte[]{ (byte) 'a', (byte) illegalSecondChar }));
+    }
+
+    @Test
+    public void headerValuesAllowSpaceAfterFirstCharacter() throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        ByteBuf buf = null;
+        try {
+            buf = encode(b(":method"), b("GET"), b("test_header"), b("a b"));
+            Http2Headers headers = decoder.decodeHeaders(1, buf); // This must not throw.
+            assertThat(headers.get("test_header")).isEqualToIgnoringCase("a b");
+        } finally {
+            ReferenceCountUtil.release(buf);
+        }
+    }
+
+    @Test
+    public void headerValuesAllowHorzontalTabAfterFirstCharacter() throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        ByteBuf buf = null;
+        try {
+            buf = encode(b(":method"), b("GET"), b("test_header"), b("a\tb"));
+            Http2Headers headers = decoder.decodeHeaders(1, buf); // This must not throw.
+            assertThat(headers.get("test_header")).isEqualToIgnoringCase("a\tb");
+        } finally {
+            ReferenceCountUtil.release(buf);
+        }
+    }
+
+    public static List<Integer> validObsText() {
+        ArrayList<Integer> list = new ArrayList<Integer>();
+        for (int i = 0x80; i <= 0xFF; i++) {
+            list.add(i);
+        }
+        return list;
+    }
+
+    @ParameterizedTest
+    @MethodSource("validObsText")
+    void headerValuesAllowObsTextInFirstChar(int i) throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        ByteBuf buf = null;
+        try {
+            byte[] bytes = {(byte) i, 'a'};
+            buf = encode(b(":method"), b("GET"), b("test_header"), bytes);
+            Http2Headers headers = decoder.decodeHeaders(1, buf); // This must not throw.
+            assertThat(headers.get("test_header")).isEqualTo(new AsciiString(bytes));
+        } finally {
+            ReferenceCountUtil.release(buf);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validObsText")
+    void headerValuesAllowObsTextInNonFirstChar(int i) throws Exception {
+        final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+        ByteBuf buf = null;
+        try {
+            byte[] bytes = {(byte) 'a', (byte) i};
+            buf = encode(b(":method"), b("GET"), b("test_header"), bytes);
+            Http2Headers headers = decoder.decodeHeaders(1, buf); // This must not throw.
+            assertThat(headers.get("test_header")).isEqualTo(new AsciiString(bytes));
+        } finally {
+            ReferenceCountUtil.release(buf);
+        }
     }
 
     private static void verifyValidationFails(final DefaultHttp2HeadersDecoder decoder, final ByteBuf buf) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -173,6 +173,23 @@ public class DefaultHttp2HeadersTest {
         assertFalse(headers.contains("2name", "Value3", false));
     }
 
+    @Test
+    void setMustOverwritePseudoHeaders() {
+        Http2Headers headers = newHeaders();
+        // The headers are already populated with pseudo headers.
+        headers.method(of("GET"));
+        headers.path(of("/index2.html"));
+        headers.status(of("101"));
+        headers.authority(of("github.com"));
+        headers.scheme(of("http"));
+        headers.set(of(":protocol"), of("http"));
+        assertEquals(of("GET"), headers.method());
+        assertEquals(of("/index2.html"), headers.path());
+        assertEquals(of("101"), headers.status());
+        assertEquals(of("github.com"), headers.authority());
+        assertEquals(of("http"), headers.scheme());
+    }
+
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {
         for (PseudoHeaderName pseudoName : PseudoHeaderName.values()) {
             assertNotNull(headers.get(pseudoName.value()));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -52,7 +52,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.reset;
@@ -664,11 +663,11 @@ public class HpackDecoderTest {
         try {
             HpackEncoder hpackEncoder = new HpackEncoder(true);
 
-            Http2Headers toEncode = new DefaultHttp2Headers();
+            Http2Headers toEncode = new DefaultHttp2Headers(false);
             toEncode.add(":test", "1");
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
-            final Http2Headers decoded = new DefaultHttp2Headers();
+            final Http2Headers decoded = new DefaultHttp2Headers(true);
 
             assertThrows(Http2Exception.StreamException.class, new Executable() {
                 @Override
@@ -687,13 +686,13 @@ public class HpackDecoderTest {
         try {
             HpackEncoder hpackEncoder = new HpackEncoder(true);
 
-            Http2Headers toEncode = new DefaultHttp2Headers();
+            Http2Headers toEncode = new DefaultHttp2Headers(false);
             toEncode.add(":test", "1");
             toEncode.add(":status", "200");
             toEncode.add(":method", "GET");
             hpackEncoder.encodeHeaders(1, in, toEncode, NEVER_SENSITIVE);
 
-            Http2Headers decoded = new DefaultHttp2Headers();
+            Http2Headers decoded = new DefaultHttp2Headers(false);
 
             hpackDecoder.decode(1, in, decoded, false);
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -23,12 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HpackDynamicTableTest {
+    private static final AsciiString FOO = AsciiString.cached("foo");
+    private static final AsciiString BAR = AsciiString.cached("bar");
+    private static final AsciiString HELLO = AsciiString.cached("hello");
+    private static final AsciiString WORLD = AsciiString.cached("world");
 
     @Test
     public void testLength() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.length());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(1, table.length());
         table.clear();
@@ -39,7 +44,7 @@ public class HpackDynamicTableTest {
     public void testSize() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry.size(), table.size());
         table.clear();
@@ -49,7 +54,7 @@ public class HpackDynamicTableTest {
     @Test
     public void testGetEntry() {
         final HpackDynamicTable table = new HpackDynamicTable(100);
-        HpackHeaderField entry = new HpackHeaderField("foo", "bar");
+        HpackHeaderField entry = new HpackHeaderField(FOO, BAR);
         table.add(entry);
         assertEquals(entry, table.getEntry(1));
         table.clear();
@@ -77,8 +82,8 @@ public class HpackDynamicTableTest {
     public void testRemove() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertNull(table.remove());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1);
         table.add(entry2);
         assertEquals(entry1, table.remove());
@@ -89,8 +94,8 @@ public class HpackDynamicTableTest {
 
     @Test
     public void testSetCapacity() {
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar");
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR);
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         final int size1 = entry1.size();
         final int size2 = entry2.size();
         HpackDynamicTable table = new HpackDynamicTable(size1 + size2);
@@ -115,8 +120,8 @@ public class HpackDynamicTableTest {
     public void testAdd() {
         HpackDynamicTable table = new HpackDynamicTable(100);
         assertEquals(0, table.size());
-        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar"); //size:3+3+32=38
-        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        HpackHeaderField entry1 = new HpackHeaderField(FOO, BAR); //size:3+3+32=38
+        HpackHeaderField entry2 = new HpackHeaderField(HELLO, WORLD);
         table.add(entry1); //success
         assertEquals(entry1.size(), table.size());
         table.setCapacity(32); //entry1 is removed from table

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class Http2ClientUpgradeCodecTest {
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -118,7 +118,7 @@ public class Http2FrameRoundtripTest {
         }).when(ctx).newPromise();
 
         writer = new DefaultHttp2FrameWriter(new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE, newTestEncoder()));
-        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, newTestDecoder()));
+        reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, false, newTestDecoder()));
     }
 
     @AfterEach

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -145,7 +145,7 @@ public class HttpConversionUtilTest {
 
     @Test
     public void stripTEHeadersAccountsForOWS() {
-        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        HttpHeaders inHeaders = new DefaultHttpHeaders(false);
         inHeaders.add(TE, " " + TRAILERS + ' ');
         Http2Headers out = new DefaultHttp2Headers();
         HttpConversionUtil.toHttp2Headers(inHeaders, out);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -71,9 +71,9 @@ public class ReadOnlyHttp2HeadersTest {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
             public void execute() {
-                ReadOnlyHttp2Headers.trailers(true, new AsciiString(":name"), new AsciiString("foo"),
+                ReadOnlyHttp2Headers.trailers(true, new AsciiString(":scheme"), new AsciiString("foo"),
                         new AsciiString("othername"), new AsciiString("goo"),
-                        new AsciiString(":pseudo"), new AsciiString("val"));
+                        new AsciiString(":path"), new AsciiString("val"));
             }
         });
     }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeadersImpl.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeadersImpl.java
@@ -26,4 +26,9 @@ public final class DefaultHeadersImpl<K, V> extends DefaultHeaders<K, V, Default
             ValueConverter<V> valueConverter, NameValidator<K> nameValidator) {
         super(nameHashingStrategy, valueConverter, nameValidator);
     }
+
+    public DefaultHeadersImpl(HashingStrategy<K> nameHashingStrategy, ValueConverter<V> valueConverter,
+                              NameValidator<K> nameValidator, int arraySizeHint, ValueValidator<V> valueValidator) {
+        super(nameHashingStrategy, valueConverter, nameValidator, arraySizeHint, valueValidator);
+    }
 }


### PR DESCRIPTION
Motivation:
In https://datatracker.ietf.org/doc/html/rfc7540#section-10.3 it says that only certain characters are valid in a header value:

> Any request or response that contains a character not permitted
> in a header field value MUST be treated as malformed (Section 8.1.2.6).
> Valid characters are defined by the "field-content" ABNF rule in
> Section 3.2 of [RFC7230].

Modification:
Add a header value validation step to HpackDecoder.

Result:
Header values are now validated against the Section 10.3, etc. rules.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
